### PR TITLE
fix: entry point for npm package, localVarRequest types, typos in test imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tebex-sdk-nodejs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tebex-sdk-nodejs",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@cypress/request": "^3.0.7",
         "@openapitools/openapi-generator-cli": "^2.15.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tebex-sdk-nodejs",
   "version": "1.1.0",
   "description": "Gaming payments done right - Tebex is the monetization platform designed to grow your gaming revenue streams",
-  "main": "dist/index.js",
+  "main": "dist/tebex.js",
   "scripts": {
     "generate-headless": "openapi-generator-cli generate -i openapi/Headless/headless-api.yaml -o src/Headless/lib --package-name TebexHeadless --invoker-package TebexHeadless -g typescript-node",
     "generate-checkout": "openapi-generator-cli generate -i openapi/Checkout/checkout-api.yaml -o src/Checkout/lib --package-name TebexCheckout --invoker-package TebexCheckout -g typescript-node",

--- a/src/tebex-request.ts
+++ b/src/tebex-request.ts
@@ -37,15 +37,8 @@ const request = require('@cypress/request');
  *     }
  * });
  */
-export function localVarRequest(incomingRequestOptions: {
-    method: string;
-    qs: any;
-    headers: any;
-    uri: string;
-    useQuerystring: boolean;
-    json: boolean;
-    body: any;
-} | any, callback: (error: any, response: any, body: any) => void) {
+
+export function localVarRequest(incomingRequestOptions: localVarRequest.Options, callback: (error: any, response: any, body: any) => void) {
     const requestOptions = {
         auth: incomingRequestOptions.auth,
         method: incomingRequestOptions.method,
@@ -54,15 +47,11 @@ export function localVarRequest(incomingRequestOptions: {
         json: incomingRequestOptions.json === true,
         qs: incomingRequestOptions.qs,
         body: incomingRequestOptions.body,
+        form: incomingRequestOptions.form,
     };
 
     if (incomingRequestOptions.useQuerystring && incomingRequestOptions.qs) {
         requestOptions.qs = incomingRequestOptions.qs;
-    }
-
-    // Add body if provided
-    if (incomingRequestOptions.body !== undefined) {
-        requestOptions.body = incomingRequestOptions.body;
     }
 
     // Use cypress request library to complete the request as needed
@@ -70,4 +59,18 @@ export function localVarRequest(incomingRequestOptions: {
         // Invoke the provided callback with the results
         callback(error, response, body);
     });
+}
+
+export namespace localVarRequest {
+    export interface Options {
+        method: string;
+        qs: any;
+        headers: any;
+        uri: string;
+        useQuerystring: boolean;
+        json: boolean;
+        body?: any;
+        auth?: any;
+        form?: any;
+    }
 }

--- a/test/Headless/headlessIntegration.test.ts
+++ b/test/Headless/headlessIntegration.test.ts
@@ -1,4 +1,4 @@
-import { Headless } from "../../src/Headless";
+import { Headless } from "../../src/headless";
 import { HeadlessApi } from "../../src/Headless/lib/api/headlessApi";
 import { Basket } from "../../src/Headless/lib/model/basket";
 import { WebstoreResponse } from "../../src/Headless/lib/model/webstoreResponse";

--- a/test/Webhooks/webhooksIntegration.test.ts
+++ b/test/Webhooks/webhooksIntegration.test.ts
@@ -1,4 +1,4 @@
-import { Webhooks } from "../../src/Webhooks";
+import { Webhooks } from "../../src/webhooks";
 import { Webhook } from "../../src/Webhook/webhook";
 
 describe("Webhooks", () => {


### PR DESCRIPTION
In this pull request I have done the following:
- change the default entry point from dist/index.js to dist/tebex.js the index.js is a blank file and the actual entrypoint is tebex.js this allows the importing of node modules by doing `import { Tebex } from "tebex-sdk-nodejs";` in projects when it went to index.js it did not work.
- fixed the type for localVarRequest defined this allows the importing import { localVarRequest } from "../../../tebex-request"; to work within the code base.
- added form & auth to localVarRequest type
- There were a few typos in the tests imports that stopped the from passing